### PR TITLE
Protractor configuration file for the frontend

### DIFF
--- a/build/protractor.conf.js
+++ b/build/protractor.conf.js
@@ -1,0 +1,38 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Configuration file for Protractor test runner.
+ *
+ * TODO(bryk): Start using ES6 in this file when supported.
+ */
+require('babel-core/register');
+var conf = require('./conf');
+var path = require('path');
+
+
+/**
+ * Exported protractor config required by the framework.
+ *
+ * Schema can be found here: https://github.com/angular/protractor/blob/master/docs/referenceConf.js
+ */
+exports.config = {
+  capabilities: {
+    'browserName': 'chrome'
+  },
+  
+  baseUrl: 'http://localhost:3000',
+
+  specs: [path.join(conf.paths.integrationTest, '**/*.js')]
+};


### PR DESCRIPTION
This is a basic config that allows to run the tests. Subsequent pull
requests will use it in Gulp tasks to run protractor tests over
development and production code.