### PR TITLE
Gulp tasks for creating Docker deployment images

### DIFF
--- a/build/backend.js
+++ b/build/backend.js
@@ -44,7 +44,7 @@ const goBackendDependencies = [
  *     default ones.
  */
 function spawnGoProcess(args, doneFn, opt_env) {
-  var goTask = child.spawn('go', args, {
+  let goTask = child.spawn('go', args, {
     env: lodash.merge(process.env, {GOPATH: conf.paths.backendTmp}, opt_env || {})
   });
 

--- a/build/conf.js
+++ b/build/conf.js
@@ -29,6 +29,16 @@ const basePath = path.join(__dirname, '../');
  */ 
 export default {
   /**
+   * Deployment constants configuration.
+   */
+  deploy: {
+    /**
+     * The name of the Docker image with the application.
+     */ 
+    imageName: 'kubernetes/console',
+  },
+
+  /**
    * Absolute paths to known directories, e.g., to source directory.
    */
   paths: {
@@ -39,6 +49,7 @@ export default {
     backendTmp: path.join(basePath, '.tmp/backend'),
     bowerComponents: path.join(basePath, 'bower_components'),
     build: path.join(basePath, 'build'),
+    deploySrc: path.join(basePath, 'src/app/deploy'),
     dist: path.join(basePath, 'dist'),
     externs: path.join(basePath, 'src/app/externs'),
     frontendSrc: path.join(basePath, 'src/app/frontend'),

--- a/build/deploy.js
+++ b/build/deploy.js
@@ -1,0 +1,75 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Gulp tasks for deploying and releasing the application.
+ */
+import child from 'child_process';
+import gulp from 'gulp';
+import path from 'path';
+
+import conf from './conf';
+
+
+/**
+ * @param {!Array<string>} args
+ * @param {function(?Error=)} doneFn
+ */
+function spawnDockerProcess(args, doneFn) {
+  let dockerTask = child.spawn('docker', args);
+
+  // Call Gulp callback on task exit. This has to be done to make Gulp dependency management
+  // work.
+  dockerTask.on('exit', function(code) {
+    if (code === 0) {
+      doneFn();
+    } else {
+      doneFn(new Error('Docker command error, code:' + code));
+    }
+  });
+
+  dockerTask.stdout.on('data', function (data) {
+    console.log('' + data);
+  });
+
+  dockerTask.stderr.on('data', function (data) {
+    console.error('' + data);
+  });
+}
+
+
+/**
+ * Creates Docker image for the application. The image is tagged with the image name configuration
+ * constant.
+ *
+ * In order to run the image on a Kubernates cluster, it has to be deployed to a registry.
+ */
+gulp.task('docker-image', ['docker-file'], function(doneFn) {
+  spawnDockerProcess([
+    'build',
+    // Remove intermediate containers after a successful build.
+    '--rm=true',
+    '--tag', conf.deploy.imageName,
+    conf.paths.dist,
+  ], doneFn);
+});
+
+
+/**
+ * Processes the Docker file and places it in the dist folder for building.
+ */
+gulp.task('docker-file', function() {
+  return gulp.src(path.join(conf.paths.deploySrc, 'Dockerfile'))
+      .pipe(gulp.dest(conf.paths.dist));
+});

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -20,6 +20,7 @@
  */
 import './build/backend';
 import './build/build';
+import './build/deploy';
 import './build/index';
 import './build/script';
 import './build/serve';


### PR DESCRIPTION
The images can later be used to, e.g., deploy to a Kubernetes cluster.