### PR TITLE
Implement simple chrome operating on ui.router

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,8 @@
     "angular-aria": "~1.4.2",
     "angular-material": "~0.10.1",
     "angular-messages": "~1.4.2",
+    "angular-ui-router": "~0.2.15",
     "angular-resource": "~1.4.2",
-    "angular-route": "~1.4.2",
     "angular-sanitize": "~1.4.2"
   },
   "devDependencies": {

--- a/build/script.js
+++ b/build/script.js
@@ -93,6 +93,8 @@ gulp.task('scripts', ['create-serve-folders'], function() {
               'google-closure-compiler/contrib/externs/angular-1.4-http-promise_templated.js'),
           path.join(conf.paths.nodeModules,
               'google-closure-compiler/contrib/externs/angular-1.4-q_templated.js'),
+          path.join(conf.paths.nodeModules,
+              'google-closure-compiler/contrib/externs/angular_ui_router.js'),
           path.join(conf.paths.externs, '**/*.js'),
         ],
         // Enable all compiler checks by default and make them errors.

--- a/src/app/frontend/chrome/chrome.controller.js
+++ b/src/app/frontend/chrome/chrome.controller.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc.
+// Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Robo Slab font.
-@import url(//fonts.googleapis.com/css?family=Roboto+Slab:400,700|Roboto:400,700,700italic,400italic);
 
-// Angular Material icon font. It allows to use the icons as fonts.
-@import url(//fonts.googleapis.com/icon?family=Material+Icons);
-
-html {
-  font-family: 'Roboto Slab', serif;
+/**
+ * Controller for the chrome directive.
+ *
+ * @final
+ */
+export default class ChromeController {
+  constructor() {
+    // TODO(bryk): This is for tests only, change to something meaningful later.
+    /** @export {string} */
+    this.clusterName = 'ClusterName';
+  }
 }

--- a/src/app/frontend/chrome/chrome.directive.js
+++ b/src/app/frontend/chrome/chrome.directive.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc.
+// Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Robo Slab font.
-@import url(//fonts.googleapis.com/css?family=Roboto+Slab:400,700|Roboto:400,700,700italic,400italic);
+import ChromeController from './chrome.controller';
 
-// Angular Material icon font. It allows to use the icons as fonts.
-@import url(//fonts.googleapis.com/icon?family=Material+Icons);
 
-html {
-  font-family: 'Roboto Slab', serif;
+/**
+ * Returns directive definition object for the chrome directive.
+ *
+ * @return {!angular.Directive}
+ */
+export default function chromeDirective() {
+  return {
+    bindToController: true,
+    controller: ChromeController,
+    controllerAs: 'ctrl',
+    templateUrl: 'chrome/chrome.html',
+    transclude: true,
+  };
 }

--- a/src/app/frontend/chrome/chrome.html
+++ b/src/app/frontend/chrome/chrome.html
@@ -1,0 +1,20 @@
+<div>
+  <md-content>
+    <md-toolbar>
+      <div class="md-toolbar-tools">
+        <md-button class="md-icon-button" aria-label="Settings">
+          <md-icon md-font-library="material-icons">menu</md-icon>
+        </md-button>
+        <h2>
+          <span>Kubernetes cluster: {{ctrl.clusterName}}</span>
+        </h2>
+        <span flex></span>
+        <md-button class="md-icon-button" aria-label="Favorite">
+          <md-icon md-font-library="material-icons">more_vert</md-icon>
+        </md-button>
+      </div>
+    </md-toolbar>
+
+    <div ng-transclude></div>
+  </md-content>
+</div>

--- a/src/app/frontend/chrome/chrome.module.js
+++ b/src/app/frontend/chrome/chrome.module.js
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import MainController from './main.controller';
+import chromeDirective from './chrome.directive';
 
 
 /**
- * @param {!angular.$routeProvider} $routeProvider
- * @ngInject
+ * Angular module containing navigation chrome for the application.
  */
-export default function routeConfig($routeProvider) {
-  $routeProvider.when('/', {
-    templateUrl: 'main/main.html',
-    controller: MainController,
-    controllerAs: 'ctrl',
-  });
-}
+export default angular.module(
+    'kubernetesConsole.chrome',
+    [
+      'ngMaterial',
+    ])
+    .directive('chrome', chromeDirective);

--- a/src/app/frontend/index.html
+++ b/src/app/frontend/index.html
@@ -26,8 +26,9 @@
       experience.</p>
     <![endif]-->
 
-    <div ng-view> <!-- Application content is inserted here. --> </div>
-
+    <chrome>
+      <div ui-view> <!-- Application content is inserted here. --> </div>
+    </chrome>
     <!-- build:js console/vendor.js -->
     <!-- bower:js -->
     <!-- Bower JS dependencies are populated here (dev build) and compiled

--- a/src/app/frontend/index.module.js
+++ b/src/app/frontend/index.module.js
@@ -16,8 +16,9 @@
  * @fileoverview Entry point module to the application. Loads and configures other modules needed
  * to bootstrap the application.
  */
-import routeConfig from './index.route';
+import chromeModule from './chrome/chrome.module';
 import mainModule from './main/main.module';
+import routeConfig from './index.route';
 
 export default angular.module(
     'kubernetesConsole',
@@ -27,8 +28,9 @@ export default angular.module(
       'ngMaterial',
       'ngMessages',
       'ngResource',
-      'ngRoute',
       'ngSanitize',
+      'ui.router',
+      chromeModule.name,
       mainModule.name,
     ])
     .config(routeConfig);

--- a/src/app/frontend/index.route.js
+++ b/src/app/frontend/index.route.js
@@ -14,9 +14,12 @@
 
 
 /**
- * @param {!angular.$routeProvider} $routeProvider
+ * Global route configuration for the application.
+ *
+ * @param {!ui.router.$urlRouterProvider} $urlRouterProvider
  * @ngInject
  */
-export default function routeConfig($routeProvider) {
-  // TODO(bryk): Configure 'otherwise' route here.
+export default function routeConfig($urlRouterProvider) {
+  // When no state is matched by an URL, redirect to default one.
+  $urlRouterProvider.otherwise('');
 }

--- a/src/app/frontend/main/main.controller.js
+++ b/src/app/frontend/main/main.controller.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc.
+// Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/app/frontend/main/main.html
+++ b/src/app/frontend/main/main.html
@@ -1,14 +1,12 @@
 <div layout="vertical" layout-fill>
-  <md-content>
-    <header>
-      Hello world! {{ctrl.testValue}}
-    </header>
+  <header>
+    Hello world! {{ctrl.testValue}}
+  </header>
 
-    <section class="jumbotron">
-      <h1>'Allo, 'Allo!</h1>
-      <p class="lead">
-        <img src="assets/images/yeoman.png" alt="I'm Yeoman"><br>
-      </p>
-    </section>
-  </md-content>
+  <section class="jumbotron">
+    <h1>'Allo, 'Allo!</h1>
+    <p class="lead">
+      <img src="assets/images/yeoman.png" alt="I'm Yeoman"><br>
+    </p>
+  </section>
 </div>

--- a/src/app/frontend/main/main.module.js
+++ b/src/app/frontend/main/main.module.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import routeConfig from './main.route';
+import stateConfig from './main.state';
 
 
 export default angular.module('kubernetesConsole.main', [])
-    .config(routeConfig);
+    .config(stateConfig);

--- a/src/app/frontend/main/main.state.js
+++ b/src/app/frontend/main/main.state.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc.
+// Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import MainController from './main.controller';
 
-body {
-  background-color: gray;
+
+/**
+ * @param {!ui.router.$stateProvider} $stateProvider
+ * @ngInject
+ */
+export default function stateConfig($stateProvider) {
+  $stateProvider.state('main', {
+    url: '',
+    templateUrl: 'main/main.html',
+    controller: MainController,
+    controllerAs: 'ctrl',
+  });
 }
-


### PR DESCRIPTION
This change implements initial version of the chrome. It uses ui.router
for routing and state management. The reason to use this router is the
fact that it is more flexible than stock one. It also resembles Angular2
router, so hypothetical migration should be easier.