### PR TITLE
chore(build): cache node_modules in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@
 
 # Explicitly set the environment to be container-based. This makes the builds faster.
 sudo: false
+# Cache downloaded Node.JS modules in the node_modules directory for faster builds.
+cache:
+  directories:
+    - node_modules
 # Use Node.js as primary language because Gulp is the build system used in the project.
 language: node_js
 before_script:


### PR DESCRIPTION
This sets the option in the Travis CI configuration to cache all the
downloaded Node.JS modules, which can senificantly speed up travis
builds.